### PR TITLE
Change type to css property in virtual-scroll-viewport.component.ts

### DIFF
--- a/libs/ngrid/src/lib/grid/features/virtual-scroll/virtual-scroll-viewport.component.ts
+++ b/libs/ngrid/src/lib/grid/features/virtual-scroll/virtual-scroll-viewport.component.ts
@@ -461,6 +461,6 @@ export class PblCdkVirtualScrollViewportComponent extends CdkVirtualScrollViewpo
 
 declare global {
   interface CSSStyleDeclaration {
-    contain: 'none' | 'strict' | 'content' | 'size' | 'layout' | 'style' | 'paint' | 'inherit' | 'initial' | 'unset';
+    contain: string
   }
 }


### PR DESCRIPTION
Fix problem for typescript for Angular 13 typings checking in CSSStyleDeclaration for contain property, it should be string, with this fix this library can be used in Angular and Angular Material 13 until a new issue is discovered, this problem could be related to latests versions of TypeScript dom library